### PR TITLE
Refactored merge-copy to use node-merge-collect-files to allow merging multiple directories and optionally filter using glob patterns.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea/
 node_modules/

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Default: `**/*`
 
 Optionally filter the files by one or more glob patterns.
 
+#### globOptions
+Type: `Object`
+Default: `{ nonull: false, dot: true }`
+
+Optionally set some glob options.
+
 
 ### Usage Examples
 
@@ -106,6 +112,10 @@ Result:
 ```
 
 ## Release History
+
+__0.2.0__
+
+  * Added support for setting glob options.
 
 __0.1.0__
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-# grunt-merge-copy v0.0.6
+# grunt-merge-copy
 
-> Merge two directories.
+## Description
 
+Merge two or more directories.
+Files can be optionally filtered using a glob pattern.
 
 
 ## Getting Started
+
 This plugin requires Grunt `~0.4.0`
 
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
@@ -20,30 +23,41 @@ grunt.loadNpmTasks('grunt-merge-copy');
 ```
 
 
-
 ## Copy task
+
 _Run this task with the `grunt merge-copy` command._
 
-Task targets, files and options may be specified according to the grunt [Configuring tasks](http://gruntjs.com/configuring-tasks) guide.
+Task targets and options may be specified according to the grunt [Configuring tasks](http://gruntjs.com/configuring-tasks) guide.
+
+
 ### Options
 
-#### common
+
+#### destination
 Type: `String`
-Default: `common`
 
-This option represents common folder name. 
+Specifies the destination directory of the merge operation.
 
-#### specific
-Type: `String`
-Default: `specific`
 
-This option represents specific folder name. 
+#### directories
+Type: `Array`
+
+An array of directories that should me merged. Order is important!
+
 
 #### encoding
-Type: `String`  
+Type: `String`
 Default: `grunt.file.defaultEncoding`
 
 The file encoding to copy files with.
+
+
+#### patterns
+Type: `String | Array`
+Default: `**/*`
+
+Optionally filter the files by one or more glob patterns.
+
 
 ### Usage Examples
 
@@ -53,24 +67,24 @@ Assuming you have following project structure:
 ```shell
 └── app
     └── base 
-    	├── apple.html
-    	├── berry.html
+        ├── apple.html
+        ├── berry.html
     └── clientx
         ├── apple.html
+        ├── banana.html
 ├── Gruntfile.js
 ```
 
 Applying following merge-copy configuration:
 
 ```js
- 'merge-copy': {
-	options: {
-		common: 'base'
-		specific: 'clientx'
-	},
-	main: {
-		files: [ { src: 'app', dest: 'dist' } ]
-	}
+'merge-copy': {
+    main: {
+        options: {
+            destination: 'dist',
+            directories: [ 'app/base/', 'app/clientx' ]
+        },
+    }
  }
 ```
 
@@ -79,13 +93,20 @@ Result:
 ```shell
 └── app
     └── base 
-    	├── apple.html
-    	├── berry.html
+        ├── apple.html
+        ├── berry.html
     └── clientx
         ├── apple.html
+        ├── banana.html
 └── dist
     ├── apple.html ( file from clientx directory )
-    ├── berry.html	
+    ├── berry.html
+    ├── banana.html
 ├── Gruntfile.js
 ```
 
+## Release History
+
+__0.1.0__
+
+  * Defined merge-copy task using [node-merge-collect-files](https://github.com/sullinger/node-merge-collect-files).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-merge-copy",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Merge two directories",
   "homepage": "https://github.com/mquintal/grunt-merge-copy",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   "_id": "grunt-merge-copy@0.0.4",
   "_from": "grunt-merge-copy@",
   "dependencies": {
-    "node-merge-collect-files": "^0.2.3"
+    "node-merge-collect-files": "^0.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-merge-copy",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "description": "Merge two directories",
   "homepage": "https://github.com/mquintal/grunt-merge-copy",
   "scripts": {
@@ -14,7 +14,7 @@
   ],
   "author": {
     "name": "Miguel Quintal",
-	  "url": "http://www.mquintal.com"
+    "url": "http://www.mquintal.com"
   },
   "repository": {
     "type": "git",
@@ -26,11 +26,14 @@
   "devDependencies": {
     "grunt": "~0.4.0"
   },
-   "peerDependencies": {
+  "peerDependencies": {
     "grunt": "~0.4.0"
   },
   "license": "ISC",
   "readmeFilename": "README.md",
   "_id": "grunt-merge-copy@0.0.4",
-  "_from": "grunt-merge-copy@"
+  "_from": "grunt-merge-copy@",
+  "dependencies": {
+    "node-merge-collect-files": "^0.2.3"
+  }
 }

--- a/tasks/merge-copy.js
+++ b/tasks/merge-copy.js
@@ -16,7 +16,7 @@ module.exports = function( grunt ) {
         };
 
 
-        var files = mergeCollectFiles( options.directories, options.patterns );
+        var files = mergeCollectFiles( options.directories, options.patterns, options.globOptions );
 
         for ( var relativeFilePath in files ) {
             if ( files.hasOwnProperty( relativeFilePath ) ) {

--- a/tasks/merge-copy.js
+++ b/tasks/merge-copy.js
@@ -1,176 +1,30 @@
+var path = require( 'path' );
+var mergeCollectFiles = require('node-merge-collect-files');
+
 module.exports = function( grunt ) {
     'use strict';
-	
-    var fs = require( 'fs' )
-      , path = require( 'path' )
-    
-    grunt.registerMultiTask( 'merge-copy', 'Merge two directories', function() {
-        var options = {
-			common: this.options().common || 'common'
-		  , specific: this.options().specific || 'specific'
-		  , encoding: this.options().encoding || grunt.file.defaultEncoding
-		};
-		
-		var copyOptions = {
-			encoding: options.encoding,
-		};
-		
-		
-         
-        /**
-         * Method responsible for returning files into given path
-         * 
-         * @param {String} basePath - path to list all files.
-         * 
-         * @date 2014-10-03
-         * */  
-        function getPathFiles( basePath ) {
-            var arrFiles = [];
-             
-            // Check if base path is a directory.
-            if( grunt.file.isDir( basePath ) ) {
-                
-                grunt.file.recurse( basePath, function( file  ) {
-                    arrFiles.push( file );
-                });
-                
-            } else {
-                grunt.log.errorlns( 'Directory "', basePath, '" NOT FOUND.' );
+
+    grunt.registerMultiTask( 'merge-copy', 'Merge two or more directories', function() {
+        var options = this.options();
+
+        if ( !options.encoding ) {
+            options.encoding = grunt.file.defaultEncoding;
+        }
+
+        var copyOptions = {
+            encoding: options.encoding
+        };
+
+
+        var files = mergeCollectFiles( options.directories, options.patterns );
+
+        for ( var key in files ) {
+            if ( files.hasOwnProperty( relativeFilePath ) ) {
+                var fileInfo = files[ relativeFilePath ];
+
+                grunt.file.copy( fileInfo.absolutePath, path.join( options.destination, relativeFilePath ), copyOptions );
             }
-            
-            return arrFiles;
         }
-        
-        
-        /**
-         * Returns all common and specific files.
-         *
-         * @date 2014-11-03
-         * */
-        function getFiles( commonDir, specificDir ) {
-            var arrCommonFiles = []
-              , arrClientFiles = [];
-            
-            return { 
-                common: getPathFiles( commonDir )
-              , specific: getPathFiles( specificDir )
-            };
-        }
-        
-        /**
-         * Returns all common and specific files.
-         * 
-         * @param {String} basePath
-         * @param {String} file
-         * 
-         * @date 2014-11-03
-         * */
-        function getRelativePath( basePath, file ) {
-            var absolutePath = path.resolve( file, '.' )
-              , relativePath = absolutePath.replace( basePath, '' );
-            
-            relativePath = relativePath.split( path.sep );
-            
-            if( relativePath[ 0 ] === '' ) {
-                relativePath.shift( );
-            }
-            relativePath.shift( );
-            
-            return relativePath.join( path.sep );
-        }
-        
-        /**
-         * Merges common and specific array.
-         *
-         * 
-         * @date 2014-11-03
-         * @author arodrigues
-         * */
-        function mergeArrays( basePath ,commonFiles, specificFiles ) {
-            var commonPath = ''
-              , specificPath = ''
-              , arrResult = []
-              , fileFound = false;
-            
-            basePath = path.resolve( basePath, '.' );
-            
-            for( var common in commonFiles ) {
-                if( commonFiles.hasOwnProperty( common ) ) {
-                    fileFound = false;
-                    commonPath = getRelativePath( basePath, commonFiles[ common ] );
-                    
-                    if( specificFiles ) {
-                        
-                        specificFiles.forEach( function( file ) {
-                            specificPath = getRelativePath( basePath, file );
-                            
-                            // Check if relative and common are equal. 
-                            if( specificPath === commonPath ) {
-                                // Delete this index from result array.
-                                arrResult.push( { relative: specificPath, absolute: file } );
-                                fileFound = true;
-                                return ;
-                            }
-                            
-                        });
-                        
-                    }
-                    
-                    if( !fileFound ) {
-                        arrResult.push( { relative: commonPath, absolute: commonFiles[ common ] } );
-                    }
-                    
-                }
-            }
-            
-            return arrResult;
-        }
-        
-        /**
-         * Copy all file to dest directory.
-         * 
-         * @param {String} dest - destination directory
-         * @param {Array} files - all files to copy [{ relative: '', absolute: '' }, ...]
-         *
-         * @date 2014-11-03
-         * @author arodrigues
-         * */
-        function copyFiles( dest, files ) {
-            dest = path.resolve( dest, '.' );
-            
-            
-            files.forEach( function( file ) {
-                var src = path.resolve( file.absolute, '.' )
-                  , destFile = path.resolve( dest + '/' + file.relative, '.' );
-                
-                // Copy file.  
-                grunt.file.copy( src, destFile, copyOptions );
-                
-                grunt.log.debug( 'File copied: \n\tfrom: ', src, '\n\tto: ' + destFile );
-            });    
-        }
-        
-        
-        this.files.forEach( function( filePair ) {
-            var source = grunt.util.kindOf( filePair.src ) === 'array' ? filePair.src[0] : filePair ||''
-              , commonDir =  [ source, options.common ].join( '/' )
-              , specificDir = [ source, options.specific ].join( '/' )
-              , files = null; 
-              
-            
-            files = getFiles( commonDir, specificDir );
-            
-            grunt.log.debug( 'Common Files: \n\t', files.common );
-            grunt.log.debug( 'Specific Files: \n\t', files.specific, '\n' );
-            
-            // Merge commoin files
-            files = mergeArrays( filePair.src[0], files.common, files.specific );
-            
-            grunt.log.debug( 'Merged Files: \n\t', files );
-            
-             // Copy all files
-            copyFiles( filePair.dest, files );
-        });
     });
 
 };

--- a/tasks/merge-copy.js
+++ b/tasks/merge-copy.js
@@ -18,7 +18,7 @@ module.exports = function( grunt ) {
 
         var files = mergeCollectFiles( options.directories, options.patterns );
 
-        for ( var key in files ) {
+        for ( var relativeFilePath in files ) {
             if ( files.hasOwnProperty( relativeFilePath ) ) {
                 var fileInfo = files[ relativeFilePath ];
 


### PR DESCRIPTION
Hi,

inspired by your code, I refactored the core logic into a node module, so other grunt tasks can make use of it as well. Additionally, I changed grunt-merge-copy to make use of this new node module.

Your grunt plugin can now
- merge two or more directories
- optionally filter the files using one or multiple glob patterns.

Hope you like the changes and will merge this pull request.
Thank you!

Stefan
